### PR TITLE
added Two-handed Finesse

### DIFF
--- a/public/data/symbaroum.json
+++ b/public/data/symbaroum.json
@@ -671,6 +671,17 @@
     "master": "Active. With the skill of a Master, the damage dealt by the main-hand weapon is 1D10 while the weapon in the other hand deals 1D8."
   },
   {
+    "id": 284,
+    "type": "Ability",
+    "name": "Two-handed Finesse",
+    "book": "MC",
+    "requirement": "",
+    "effect": "Most people fighting with a two-handed weapon rely on its considerable weight, but there are also those who cultivate the ability to wield huge two-handed swords with great finesse. Those who possess this ability belong to that category, and can use the length of the weapon to combat all sorts of opponents.",
+    "novice": "Passive. In the hands of the novice, two-handed swords gain the quality Long and can therefore be used with the Polearm Mastery ability.",
+    "adept": "Reaction. After one successful Defense per turn, pass a [Strong←Strong] test to push enemies out of melee combat with the sword. The enemy takes 1D6 damage, is pushed back a couple of meters, and must once again face the quality Long.",
+    "master": "Active. The master’s flowing strikes count as a chain of attacks against enemies within melee distance – if an enemy is hit, an attack is made against the next one, and so on until an attack fails."
+  },
+  {
     "id": 143,
     "type": "Ability",
     "name": "Two-handed Force",


### PR DESCRIPTION
I added the Two-handed Finesse ability from the Symbaroum Monster Codex. Some decisions I had to make along the way where:

1.  Which "id" to use? I just used the next free number, which happened to be 284, since I did not recognize a specific scheme of assigning IDs.
2.  I chose "MC" (for "Monster Codex") as the value of "book", which did not yet exist.
3. I let the "requirement" empty, since, while the ability comes from the description of the queenly Pansars, I did not get the feeling that those are the only ones using this technique, but I might be wrong.