### PR TITLE
focus v-select upon initial creation of card

### DIFF
--- a/src/components/card.vue
+++ b/src/components/card.vue
@@ -2,7 +2,7 @@
     <div class="card" :id="id">
         <div class="card-header">
             <button @click="previous" :disabled="noPrevious()"><icon id="arrow-left" :button="true"></icon></button>
-            <v-select :options="options" v-model="selected" placeholder="Start typing..."></v-select>
+            <v-select ref="inputSelected" :options="options" v-model="selected" placeholder="Start typing..."></v-select>
             <button @click="next" :disabled="noNext()"><icon id="arrow-right" :button="true"></icon></button>
             <button class="remove-card" @click="$emit('dismiss', id)"><icon id="cross" :button="true"></icon></button>
         </div>
@@ -128,6 +128,12 @@
         created() {
             if (this.preSelected) {
                 this.selected = this.preSelected;
+            }
+        },
+
+        mounted() {
+            if (!this.selected) {
+                this.$refs.inputSelected.$refs.search.focus();
             }
         },
     };


### PR DESCRIPTION
For convenience it the focus should be in the "autocomplete" when adding a new card, such that we can immediately start typing to select the new ability/power/trait.