### PR TITLE
Support for Power-Levels in URL and on Cards

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -290,11 +290,22 @@ button {
     input[type=search], input[type=search]:focus {
         float: none !important;
         height: 37px !important;
-        width: 100% !important;
+        width: 90% !important;
     }
 
     .selected-tag {
         display: none !important;
+    }
+
+    &.power-level {
+        margin-left: 1rem !important;
+        width:10% !important;
+
+        .selected-tag {
+            border: none;
+            background-color: $yellow;
+            display: inherit !important;
+        }
     }
 
     .dropdown-menu {

--- a/src/components/card.vue
+++ b/src/components/card.vue
@@ -4,6 +4,7 @@
             <button @click="previous" :disabled="noPrevious()"><icon id="arrow-left" :button="true"></icon></button>
             <v-select :options="options" v-model="selected" placeholder="Start typing..."></v-select>
             <button @click="next" :disabled="noNext()"><icon id="arrow-right" :button="true"></icon></button>
+            <v-select class="power-level" :options="powerLevels()" v-model="powerLevel"></v-select>
             <button class="remove-card" @click="$emit('dismiss', id)"><icon id="cross" :button="true"></icon></button>
         </div>
 
@@ -34,15 +35,15 @@
                     <strong>Traits:</strong> {{ selected.traits }}
                 </p>
                 <div v-if="selected.novice">
-                    <div class="line" v-if="selected.novice && showLevel(1)">
+                    <div class="line" v-if="showNovice">
                         <strong>Novice:</strong>
                         <p v-html="emphasizeFirstWord(selected.novice)"></p>
                     </div>
-                    <div class="line" v-if="selected.adept && showLevel(2)">
+                    <div class="line" v-if="showAdept">
                         <strong>Adept:</strong>
                         <p v-html="emphasizeFirstWord(selected.adept)"></p>
                     </div>
-                    <div class="line" v-if="selected.master && showLevel(3)">
+                    <div class="line" v-if="showMaster">
                         <strong>Master:</strong>
                         <p v-html="emphasizeFirstWord(selected.master)"></p>
                     </div>
@@ -60,6 +61,7 @@
     export default {
         props: [
             'id',
+            'index',
             'options',
             'preSelected',
         ],
@@ -67,7 +69,7 @@
         data() {
             return {
                 selected: null,
-                level: null,
+                powerLevel: null,
             };
         },
 
@@ -122,7 +124,18 @@
             },
 
             showLevel(i) {
-              return !this.selected.level || this.normalizeLevel(this.selected.level) >= i;
+              return !this.powerLevel || this.normalizeLevel(this.powerLevel) >= i;
+            },
+
+            isMonstrousTrait() {
+              return this.selected && this.selected.type == 'Monstrous Trait';
+            },
+
+            powerLevels() {
+              if (this.selected) {
+                return this.isMonstrousTrait() ? ["I","II","III"] : ["N","A","M"];
+              }
+              return [];
             }
         },
 
@@ -132,12 +145,31 @@
                     this.$emit('change', newVal);
                 }
             },
+            powerLevel(newVal, oldVal) {
+                if (newVal !== oldVal) {
+                    this.$parent.cards[this.index].powerLevel = newVal;
+                    this.$parent.setCardIDsIntoURL();
+                }
+            },
         },
 
         created() {
             if (this.preSelected) {
                 this.selected = this.preSelected;
+                this.powerLevel = this.preSelected.powerLevel;
             }
+        },
+
+        computed: {
+          showNovice() {
+            return this.selected.novice && this.showLevel(1);
+          },
+          showAdept() {
+            return this.selected.adept && this.showLevel(2);
+          },
+          showMaster() {
+            return this.selected.master && this.showLevel(3);
+          },
         },
     };
 </script>

--- a/src/components/card.vue
+++ b/src/components/card.vue
@@ -34,15 +34,15 @@
                     <strong>Traits:</strong> {{ selected.traits }}
                 </p>
                 <div v-if="selected.novice">
-                    <div class="line" v-if="selected.novice">
+                    <div class="line" v-if="selected.novice && showLevel(1)">
                         <strong>Novice:</strong>
                         <p v-html="emphasizeFirstWord(selected.novice)"></p>
                     </div>
-                    <div class="line" v-if="selected.adept">
+                    <div class="line" v-if="selected.adept && showLevel(2)">
                         <strong>Adept:</strong>
                         <p v-html="emphasizeFirstWord(selected.adept)"></p>
                     </div>
-                    <div class="line" v-if="selected.master">
+                    <div class="line" v-if="selected.master && showLevel(3)">
                         <strong>Master:</strong>
                         <p v-html="emphasizeFirstWord(selected.master)"></p>
                     </div>
@@ -67,6 +67,7 @@
         data() {
             return {
                 selected: null,
+                level: null,
             };
         },
 
@@ -115,6 +116,14 @@
 
                 return false;
             },
+
+            normalizeLevel(x) {
+              return Math.max(['N','A','M'].indexOf(x), ['I','II','III'].indexOf(x), ['1','2','3'].indexOf(x)) + 1;
+            },
+
+            showLevel(i) {
+              return !this.selected.level || this.normalizeLevel(this.selected.level) >= i;
+            }
         },
 
         watch: {

--- a/src/components/symbook.vue
+++ b/src/components/symbook.vue
@@ -5,6 +5,7 @@
       <card
         v-for="(card, index) in cards"
         :id="card.id"
+        :index="index"
         :options="options"
         :pre-selected="card.name ? card : null"
         :key="card.id"
@@ -80,7 +81,7 @@
 
       setCardIDsIntoURL() {
         const ids = this.cards.filter(c => !!c.id)
-          .map(card => card.id + (card.level ? `.${card.level}` : '')).join('-');
+          .map(card => card.id + (card.powerLevel ? `.${card.powerLevel}` : '')).join('-');
         if (ids) {
           const urlParams = new URLSearchParams(`c=${ids}`);
           history.pushState(null, '', `/?${urlParams.toString()}`);
@@ -92,7 +93,6 @@
       cardChange(newCard, index) {
         this.cards.splice(index, 1, newCard);
       },
-
     },
 
     watch: {
@@ -118,7 +118,7 @@
             this.cards = this.options.flatMap(opt => {
               const id = idsAtLevel.find(id => id.id == opt.id);
               if (id) {
-                opt.level = id.level;
+                opt.powerLevel = id.level;
                 return [opt];
               }
               return [];


### PR DESCRIPTION
In the URL power-levels may be specified for each ID by appending a dot (".") and the level in form of either a number (1, 2, 3), a roman numeral (I, II, III), or a letter (N, A, M).

On each card there is a v-select that allows us to choose a power-level for this card. For Monstrous Traits the levels default to I, II, III; for all other abilities/powers to N, A, M.

Only power-levels up to the specified one (or all if none is specified) are shown on the card.

This gives use the opportunity to create URL bookmarks for specific (N)PCs that also covers the proficiency in each ability.